### PR TITLE
add benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,43 @@
+name: Run benchmarks
+on:
+    schedule:
+      # Run every day at midnight.
+      - cron: "0 0 * * *"
+
+jobs:
+  benchmark:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    name: run benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: boa-dev/boa
+          path: boa
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            boa/target
+            !boa/target/doc_upload
+            ~boa/.cargo/git
+            ~boa/.cargo/registry
+          key: ${{ runner.os }}-cargo-doc-bench-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run benchmark
+        run: |
+            cd boa
+            cargo bench -p boa_engine -- --output-format bencher | tee output.txt
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1.19.3
+        with:
+          name: Boa Benchmarks
+          tool: "cargo"
+          output-file-path: output.txt
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   benchmark:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     name: run benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -15,11 +14,9 @@ jobs:
         with:
           repository: boa-dev/boa
           path: boa
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
-          profile: minimal
       - name: Cache cargo
         uses: actions/cache@v4
         with:
@@ -29,10 +26,15 @@ jobs:
             ~boa/.cargo/git
             ~boa/.cargo/registry
           key: ${{ runner.os }}-cargo-doc-bench-${{ hashFiles('**/Cargo.lock') }}
+      - name: Checkout the website-data repository
+        uses: actions/checkout@v4
+        with:
+          path: website-data
       - name: Run benchmark
         run: |
             cd boa
-            cargo bench -p boa_engine -- --output-format bencher | tee output.txt
+            cargo bench -p boa_engine -- --output-format bencher | tee ../website-data/output.txt
+            cd ../website-data
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.19.3
         with:

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -50,3 +50,8 @@ jobs:
           git config --local user.name "GitHub Action"
           git add test262
           git commit -m "Add new test262 results" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}


### PR DESCRIPTION
Is it possible to checkout once and have both benchmarks and test262 use the same checkout job? Currently the checkout is duplicated